### PR TITLE
merge hex-static.nvim into nibbler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ You can install and configure the plugin using the following options in your `pl
 
 Have the cursor over a number an call one of the following commands:
 
-| Function                 | Description                                                    |
-| ------------------------ | -------------------------------------------------------------- |
-| NibblerToHex             | Convert number under cursor/highlighted to hexadecimal         |
-| NibblerToBin             | Convert number under cursor/highlighted to binary              |
-| NibblerToDec             | Convert number under cursor/highlighted to decimal             |
-| NibblerToggle            | Toggle between binary, decimal, and hexadecimal                |
-| NibblerToggleDisplay     | Toggle virtual text showing decimal value of hex or bin number |
-| NibblerHexStringToCArray | Converts a hexadecimal string to a C-style array               |
+| Function                 | Description                                                         |
+| ------------------------ | ------------------------------------------------------------------- |
+| NibblerToHex             | Convert number under cursor/highlighted to hexadecimal              |
+| NibblerToBin             | Convert number under cursor/highlighted to binary                   |
+| NibblerToDec             | Convert number under cursor/highlighted to decimal                  |
+| NibblerToggle            | Toggle between binary, decimal, and hexadecimal                     |
+| NibblerToggleDisplay     | Toggle virtual text showing decimal value of hex or bin number      |
+| NibblerToCArray          | Convert number under cursor/highlighted to a C-Style array of bytes |
+| NibblerHexStringToCArray | Convert a hexadecimal string to a C-style array of bytes            |

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Nibbler
 
-Nibbler is a NeoVim plugin that allows you to convert numbers between binary, decimal, 
-and hexadecimal formats quickly and easily. It also provides a convenient command to 
+Nibbler is a NeoVim plugin that allows you to convert numbers between binary, decimal,
+and hexadecimal formats quickly and easily. It also provides a convenient command to
 toggle between the different number formats.
 
 ![](preview_nibbler.gif)
 
-This plugin was developed with multiple objectives: to explore the potential of AI-assisted code development, gain hands-on experience in creating neovim plugins and their practical applications, learn the basics of the Lua programming language, and cater to the specific needs of embedded programming. 
+This plugin was developed with multiple objectives: to explore the potential of AI-assisted
+code development, gain hands-on experience in creating neovim plugins and their practical
+applications, learn the basics of the Lua programming language, and cater to the specific
+needs of embedded programming.
 
 ## Features
 
@@ -14,13 +17,15 @@ This plugin was developed with multiple objectives: to explore the potential of 
 - Convert a number to its decimal representation
 - Convert a number to its hexadecimal representation
 - Toggle between binary, decimal, and hexadecimal representations
-- Diplay the decimal representation of a hexadecimal or binary number as virtual text.
+- Diplay the decimal representation of a hexadecimal or binary number as virtual text
+- Convert a hexadecimal string to a C-style array
 
 ## Installation & Configuration
 
 ### lazy.nvim
 
-You can install and configure the plugin using the following options in your `plugins.lua` file. 
+You can install and configure the plugin using the following options in your `plugins.lua` file.
+
 ```lua
 {
     { 'skosulor/nibbler' },
@@ -30,18 +35,17 @@ You can install and configure the plugin using the following options in your `pl
         })
     end
 }
-````
+```
 
 ## Usage
 
 Have the cursor over a number an call one of the following commands:
 
-| Function             | Description                                                    |
-|----------------------|----------------------------------------------------------------|
-| NibblerToHex         | Convert number under cursor/highlighted to hexadecimal         |
-| NibblerToBin         | Convert number under cursor/highlighted to binary              |
-| NibblerToDec         | Convert number under cursor/highlighted to decimal             |
-| NibblerToggle        | Toggle between binary, decimal, and hexadecimal                |
-| NibblerToggleDisplay | Toggle virtual text showing decimal value of hex or bin number |
-
-
+| Function                 | Description                                                    |
+| ------------------------ | -------------------------------------------------------------- |
+| NibblerToHex             | Convert number under cursor/highlighted to hexadecimal         |
+| NibblerToBin             | Convert number under cursor/highlighted to binary              |
+| NibblerToDec             | Convert number under cursor/highlighted to decimal             |
+| NibblerToggle            | Toggle between binary, decimal, and hexadecimal                |
+| NibblerToggleDisplay     | Toggle virtual text showing decimal value of hex or bin number |
+| NibblerHexStringToCArray | Converts a hexadecimal string to a C-style array               |

--- a/lua/nibbler/edits.lua
+++ b/lua/nibbler/edits.lua
@@ -1,0 +1,79 @@
+local M = {}
+
+function M.get_selected_range()
+    return {
+        start_row = vim.fn.line("'<"),
+        start_col = vim.fn.col("'<"),
+        end_row = vim.fn.line("'>"),
+        end_col = vim.fn.col("'>"),
+    }
+end
+
+function M.get_word_under_cursor_range()
+    local current_line_index, current_column_index = unpack(vim.api.nvim_win_get_cursor(0))
+    local line = vim.fn.getline('.')
+    local _, cword_start, cword_end = unpack(vim.fn.matchstrpos(line,
+        [[\k*\%]] .. current_column_index + 1 .. [[c\k*]]))
+
+    return {
+        start_row = current_line_index,
+        start_col = cword_start + 1,
+        end_row = current_line_index,
+        end_col = cword_end
+    }
+end
+
+function M.get_selected_lines()
+    local range = M.get_selected_range()
+    local text = vim.api.nvim_buf_get_lines(0, range.start_row - 1, range.end_row, false)
+    local text_length = #text
+    local end_col = math.min(#text[text_length], range.end_col)
+    local end_idx = vim.str_byteindex(text[text_length], end_col)
+    local start_idx = vim.str_byteindex(text[1], range.start_col)
+
+    text[text_length] = text[text_length]:sub(1, end_idx)
+    text[1] = text[1]:sub(start_idx or 0)
+
+    return text
+end
+
+function M.get_selected_text()
+    local selected_lines = M.get_selected_lines()
+    return table.concat(selected_lines, "\n")
+end
+
+function M.get_word_under_cursor()
+    return vim.fn.expand("<cword>")
+end
+
+function M.replace_range_with(range, to_insert)
+    if type(to_insert) == "table" then
+        to_insert = table.concat(to_insert, "\n")
+    end
+    local edits = {
+        {
+            range = {
+                ["start"] = {
+                    line = range.start_row - 1,
+                    character = range.start_col - 1,
+                },
+                ["end"] = {
+                    line = range.end_row - 1,
+                    character = range.end_col,
+                },
+            },
+            newText = to_insert
+        }
+    }
+    vim.lsp.util.apply_text_edits(edits, 0, "utf-16")
+end
+
+function M.replace_selection_with(to_insert)
+    M.replace_range_with(M.get_selected_range(), to_insert)
+end
+
+function M.replace_word_under_cursor_with(to_insert)
+    M.replace_range_with(M.get_word_under_cursor_range(), to_insert)
+end
+
+return M

--- a/lua/nibbler/init.lua
+++ b/lua/nibbler/init.lua
@@ -54,7 +54,7 @@ end
 local function toggle_base()
     local word = get_word_under_cursor()
     if word then
-        local number, base = parse_number(word)
+        local number, _ = parse_number(word)
         if number then
             if string.match(word, '^0b') then
                 replace_word_under_cursor(tostring(number))
@@ -110,7 +110,7 @@ local function convert_selected_base(target_base, toggle)
     if first_line == last_line and start_pos[3] == end_pos[3] and first_line == cursor_line and start_pos[3] == cursor_col then
         local word = get_word_under_cursor()
         if word then
-            local number, base = parse_number(word)
+            local number, _ = parse_number(word)
             if number then
                 if toggle then
                     toggle_base()
@@ -125,7 +125,7 @@ local function convert_selected_base(target_base, toggle)
             local words = vim.fn.split(current_line, '\\s\\+')
 
             for i, word in ipairs(words) do
-                local number, base = parse_number(word)
+                local number, _ = parse_number(word)
                 if number then
                     if toggle then
                         if string.match(word, '^0b') then

--- a/lua/nibbler/init.lua
+++ b/lua/nibbler/init.lua
@@ -89,11 +89,6 @@ local function display_decimal_representation()
     end
 end
 
-api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI" }, {
-    group = api.nvim_create_augroup("NibblerDecimalRepresentation", { clear = true }),
-    callback = display_decimal_representation
-})
-
 local function toggle_real_time_display()
     display_enabled = not display_enabled
     if not display_enabled then
@@ -152,35 +147,39 @@ local function convert_selected_base(target_base, toggle)
     end
 end
 
-api.nvim_create_user_command("NibblerToggle", function() convert_selected_base(nil, true) end, {
-    nargs = '?',
-    range = true,
-    desc = "Toggles between binary, decimal, and hexadecimal representations",
-})
-api.nvim_create_user_command("NibblerToHex", function() convert_selected_base('hex', false) end, {
-    nargs = '?',
-    range = true,
-    desc = "Converts a number to its hexadecimal representation"
-})
-api.nvim_create_user_command("NibblerToBin", function() convert_selected_base('bin', false) end, {
-    nargs = '?',
-    range = true,
-    desc = "Converts a number to its binary representation"
-})
-api.nvim_create_user_command("NibblerToDec", function() convert_selected_base('dec', false) end, {
-    nargs = '?',
-    range = true,
-    desc = "Converts a number to its decimal representation"
-})
-api.nvim_create_user_command("NibblerToggleDisplay", toggle_real_time_display, {
-    nargs = '?',
-    desc = "Toggle virtual text showing decimal value of hex or bin number"
-})
-
 function M.setup(opts)
     if opts and opts.display_enabled ~= nil then
         display_enabled = opts.display_enabled
     end
+
+    api.nvim_create_user_command("NibblerToggle", function() convert_selected_base(nil, true) end, {
+        nargs = '?',
+        range = true,
+        desc = "Toggles between binary, decimal, and hexadecimal representations",
+    })
+    api.nvim_create_user_command("NibblerToHex", function() convert_selected_base('hex', false) end, {
+        nargs = '?',
+        range = true,
+        desc = "Converts a number to its hexadecimal representation"
+    })
+    api.nvim_create_user_command("NibblerToBin", function() convert_selected_base('bin', false) end, {
+        nargs = '?',
+        range = true,
+        desc = "Converts a number to its binary representation"
+    })
+    api.nvim_create_user_command("NibblerToDec", function() convert_selected_base('dec', false) end, {
+        nargs = '?',
+        range = true,
+        desc = "Converts a number to its decimal representation"
+    })
+    api.nvim_create_user_command("NibblerToggleDisplay", toggle_real_time_display, {
+        nargs = '?',
+        desc = "Toggle virtual text showing decimal value of hex or bin number"
+    })
+    api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI" }, {
+        group = api.nvim_create_augroup("NibblerDecimalRepresentation", { clear = true }),
+        callback = display_decimal_representation
+    })
 end
 
 return M

--- a/lua/nibbler/init.lua
+++ b/lua/nibbler/init.lua
@@ -150,16 +150,35 @@ local function convert_selected_base(target_base, toggle)
             end
 
             local new_line = table.concat(words, ' ')
-            api.nvim_buf_set_lines(0, line_number - 1, line_number, false, {new_line})
+            api.nvim_buf_set_lines(0, line_number - 1, line_number, false, { new_line })
         end
     end
 end
 
-api.nvim_create_user_command("NibblerToggle", function() convert_selected_base(nil, true) end, { nargs='?', range=true })
-api.nvim_create_user_command("NibblerToHex", function() convert_selected_base('hex', false) end, { nargs='?', range=true })
-api.nvim_create_user_command("NibblerToBin", function() convert_selected_base('bin', false) end, { nargs='?', range=true })
-api.nvim_create_user_command("NibblerToDec", function() convert_selected_base('dec', false) end, { nargs='?', range=true })
-api.nvim_create_user_command("NibblerToggleDisplay", toggle_real_time_display, { nargs='?' })
+api.nvim_create_user_command("NibblerToggle", function() convert_selected_base(nil, true) end, {
+    nargs = '?',
+    range = true,
+    desc = "Toggles between binary, decimal, and hexadecimal representations",
+})
+api.nvim_create_user_command("NibblerToHex", function() convert_selected_base('hex', false) end, {
+    nargs = '?',
+    range = true,
+    desc = "Converts a number to its hexadecimal representation"
+})
+api.nvim_create_user_command("NibblerToBin", function() convert_selected_base('bin', false) end, {
+    nargs = '?',
+    range = true,
+    desc = "Converts a number to its binary representation"
+})
+api.nvim_create_user_command("NibblerToDec", function() convert_selected_base('dec', false) end, {
+    nargs = '?',
+    range = true,
+    desc = "Converts a number to its decimal representation"
+})
+api.nvim_create_user_command("NibblerToggleDisplay", toggle_real_time_display, {
+    nargs = '?',
+    desc = "Toggle virtual text showing decimal value of hex or bin number"
+})
 
 function M.setup(opts)
     if opts and opts.display_enabled ~= nil then
@@ -168,4 +187,3 @@ function M.setup(opts)
 end
 
 return M
-

--- a/lua/nibbler/init.lua
+++ b/lua/nibbler/init.lua
@@ -71,7 +71,7 @@ local function clear_virtual_text()
     api.nvim_buf_clear_namespace(0, ns_id, 0, -1)
 end
 
-function display_decimal_representation()
+local function display_decimal_representation()
     if not display_enabled then
         return
     end
@@ -89,13 +89,10 @@ function display_decimal_representation()
     end
 end
 
-vim.cmd([[
-augroup NibblerDecimalRepresentation
-autocmd!
-autocmd CursorMoved * lua display_decimal_representation()
-autocmd CursorMovedI * lua display_decimal_representation()
-augroup END
-]])
+api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI" }, {
+    group = api.nvim_create_augroup("NibblerDecimalRepresentation", { clear = true }),
+    callback = display_decimal_representation
+})
 
 local function toggle_real_time_display()
     display_enabled = not display_enabled

--- a/lua/nibbler/init.lua
+++ b/lua/nibbler/init.lua
@@ -137,9 +137,27 @@ local function convert_selected_base(target_base, toggle)
     end
 end
 
+local function is_hexstring(text)
+    local stripped = text:gsub("%s+", "")
+
+    local non_hex_digits = stripped:gsub("%x+", "")
+    if #non_hex_digits ~= 0 then
+        print("ERROR: text contains non hexadecimal digits '" .. non_hex_digits .. "'")
+        return false
+    end
+
+    if #stripped % 2 ~= 0 then
+        print("ERROR: text does not contain an even number of digits (" .. #stripped .. " digits found)")
+        return false
+    end
+
+    return true
+end
+
 local function hexstring_to_c_arrray(args)
     local text = nil
     local range = nil
+
     if args.range == 0 then
         text = edits.get_word_under_cursor()
         range = edits.get_word_under_cursor_range()
@@ -147,6 +165,11 @@ local function hexstring_to_c_arrray(args)
         text = edits.get_selected_text()
         range = edits.get_selected_range()
     end
+
+    if not is_hexstring(text) then
+        return
+    end
+
     edits.replace_range_with(range, text:gsub("%x%x", "0x%1, "):sub(1, -3))
 end
 

--- a/lua/nibbler/init.lua
+++ b/lua/nibbler/init.lua
@@ -147,6 +147,21 @@ local function convert_selected_base(target_base, toggle)
     end
 end
 
+local function hexstring_to_c_arrray(args)
+    local edits = require("nibbler.edits")
+    local text = nil
+    local range = nil
+    if args.range == 0 then
+        text = edits.get_word_under_cursor()
+        range = edits.get_word_under_cursor_range()
+    elseif args.range == 2 then
+        text = edits.get_selected_text()
+        range = edits.get_selected_range()
+    end
+    edits.replace_range_with(range, text:gsub("%x%x", "0x%1, "):sub(1, -3))
+end
+
+
 function M.setup(opts)
     if opts and opts.display_enabled ~= nil then
         display_enabled = opts.display_enabled
@@ -175,6 +190,10 @@ function M.setup(opts)
     api.nvim_create_user_command("NibblerToggleDisplay", toggle_real_time_display, {
         nargs = '?',
         desc = "Toggle virtual text showing decimal value of hex or bin number"
+    })
+    api.nvim_create_user_command("NibblerHexStringToCArray", hexstring_to_c_arrray, {
+        range = true,
+        desc = "Converts a hexadecimal string to a C-style array",
     })
     api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI" }, {
         group = api.nvim_create_augroup("NibblerDecimalRepresentation", { clear = true }),


### PR DESCRIPTION
Hi,

As discussed [here](https://www.reddit.com/r/neovim/comments/12aso4b/comment/jewggjs/?context=3), this is a PR to merge [hex-static.nvim](https://github.com/meuter/hex-static.nvim) into nibbler. Here is quick summary:

- [x] added `desc` field for each command
- [x] used lua api for the definition of the autocommand used to display the virtual text
- [x] added NibblerHexStringToCArray command that works on current word in normal mode and on the selection in visual mode
- [x] updated the README
- [x] avoid duplicate functions where possible.

I tested everything as much as I could, but a second pair of eyes 👀 on it might be good.
Let me know what you think. 

Thanks! 

EDIT: typo